### PR TITLE
use backwardsCompatibleDispatch to support both old and new versions of the Symfony EventDispatcher

### DIFF
--- a/src/RawSocketTransportProvider.php
+++ b/src/RawSocketTransportProvider.php
@@ -74,7 +74,7 @@ class RawSocketTransportProvider extends AbstractRouterTransportProvider
             $session->dispatchMessage($msg);
         });
 
-        $this->router->getEventDispatcher()->dispatch('connection_open', new ConnectionOpenEvent($session));
+        $this->router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionOpenEvent($session), 'connection_open');
 
         $conn->on('data', [$transport, 'handleData']);
         $conn->on('close', $this->handleClose($conn));
@@ -92,7 +92,7 @@ class RawSocketTransportProvider extends AbstractRouterTransportProvider
             $session = $this->sessions[$conn];
             $this->sessions->detach($conn);
 
-            $this->router->getEventDispatcher()->dispatch('connection_close', new ConnectionCloseEvent($session));
+            $this->router->getEventDispatcher()->backwardsCompatibleDispatch(new ConnectionCloseEvent($session), 'connection_close');
         };
     }
 


### PR DESCRIPTION
Blocked by https://github.com/voryx/Thruway/pull/331

This uses the new `backwardsCompatibleDispatch` method added to https://github.com/voryx/Thruway to allow for consistent calls to the event dispatcher across all supported Symfony versions.
Users can still call `dispatch` if they want, but the parameters order will depend on their version of Symfony, i.e. using `eventName` first will only work for Symfony < 5.0 and using `eventName` last will only work for Symfony >= 4.3.